### PR TITLE
Use Milestone name as release name

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -14,12 +14,12 @@ jobs:
       - name: 🏷️ Set tag name
         run: echo TAG_NAME=${MILESTONE_NAME%% *} >> $GITHUB_ENV
       - name: 📝 Generate Changelog
-        run: echo "# ${{ env.MILESTONE_NAME }}" > ${{ github.workspace }}-CHANGELOG.txt
+        run: echo "# ${{ env.TAG_NAME }}" > ${{ github.workspace }}-CHANGELOG.txt
       - name: 📦 Release
         uses: softprops/action-gh-release@v1
         with:
+          name: ${{ env.MILESTONE_NAME }}
           body_path: ${{ github.workspace }}-CHANGELOG.txt
           draft: true
           tag_name: ${{ env.TAG_NAME }}
-          files: ./
           generate_release_notes: true


### PR DESCRIPTION
Uses `name` directive to set release name to milestone name

Removes `files` because:
`🤔 Pattern './' does not match any files.`