### PR TITLE
Find and fix syntax error with prettier

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,18 +2,18 @@ changelog:
   categories:
     - title: Breaking Changes 🪅
       labels:
-        - "breaking :broken_heart:"
+        - 'breaking :broken_heart:'
     - title: New Features 🎉
       labels:
-        - "enhancement :heavy_plus_sign:"
-    - title: Bugfixes :bug:
+        - 'enhancement :heavy_plus_sign:'
+    - title: 'Bugfixes :bug:'
       labels:
-        - "bug :bug:"
-    - title: Maintenance :nut_and_bolt:
+        - 'bug :bug:'
+    - title: 'Maintenance :nut_and_bolt:'
       labels:
-        - "maintenance :wrench:"
-        - "CI :test_tube:"
-        - "CD :building_construction:"
+        - 'maintenance :wrench:'
+        - 'CI :test_tube:'
+        - 'CD :building_construction:'
     - title: Other Changes
       labels:
         - '*'


### PR DESCRIPTION
Fixes yml syntax error.

Found by using prettier (rather, found by prettier not reformatting on save).